### PR TITLE
feat: Add heatsink contact area calculator

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -52,6 +52,23 @@
                         <div class="input-group"> <label for="t_ambient_inlet">Inlet Air Temp [°C]:</label> <input type="number" id="t_ambient_inlet" name="t_ambient_inlet" value="{{ initial_environment.t_ambient_inlet }}" step="0.1" required title="Temperature of the air entering the heatsink"> </div>
                         <div class="input-group"> <label for="Q_total_m3_h">Air Flow Rate [m³/h]:</label> <input type="number" id="Q_total_m3_h" name="Q_total_m3_h" value="{{ initial_environment.Q_total_m3_h }}" step="10" min="1" required title="Total volumetric air flow rate through the heatsink"> </div>
                     </fieldset>
+
+                    <fieldset class="params-fieldset" id="heatsink-designer-fieldset">
+                        <legend>Heatsink Designer</legend>
+                        <p><strong>Heatsink:</strong></p>
+                        <div class="input-group"> <label for="heatsink_designer_lx">Length (X) [m]:</label> <input type="number" id="heatsink_designer_lx" name="heatsink_designer_lx" value="0.2" step="0.01" min="0.01" required title="Heatsink length in the X direction"> </div>
+                        <div class="input-group"> <label for="heatsink_designer_ly">Width (Y) [m]:</label> <input type="number" id="heatsink_designer_ly" name="heatsink_designer_ly" value="0.15" step="0.01" min="0.01" required title="Heatsink width in the Y direction (dimension along which fins are placed)"> </div>
+                        <p><strong>Fins:</strong></p>
+                        <div class="input-group"> <label for="fin_height">Height [m]:</label> <input type="number" id="fin_height" name="fin_height" value="0.05" step="0.001" min="0.001" required title="Height of a single fin"> </div>
+                        <div class="input-group"> <label for="fin_width">Width [m]:</label> <input type="number" id="fin_width" name="fin_width" value="0.002" step="0.0001" min="0.0001" required title="Thickness of a single fin"> </div>
+                        <div class="input-group"> <label for="num_fins">Number of fins:</label> <input type="number" id="num_fins" name="num_fins" value="20" step="1" min="1" required title="Total number of fins"> </div>
+                        <p><strong>Hollow Fins (per main fin):</strong></p>
+                        <div class="input-group"> <label for="hollow_fin_length">Length [m]:</label> <input type="number" id="hollow_fin_length" name="hollow_fin_length" value="0.04" step="0.001" min="0.001" title="Length of the hollow channel along the main fin"> </div>
+                        <div class="input-group"> <label for="hollow_fin_width">Width [m]:</label> <input type="number" id="hollow_fin_width" name="hollow_fin_width" value="0.001" step="0.0001" min="0.0001" title="Width of the hollow channel"> </div>
+                        <div class="input-group"> <label for="num_hollow_fins">Number of hollow fins:</label> <input type="number" id="num_hollow_fins" name="num_hollow_fins" value="1" step="1" min="0" title="Number of hollow sections per main fin (0 for solid fin)"> </div>
+                        <button type="button" id="calculate_area_button" class="action-button" style="margin-top: 10px;">Calculate Contact Area</button>
+                        <div id="heatsink_area_result" style="margin-top: 10px; font-weight: bold;"></div>
+                    </fieldset>
                 </div> <!-- End of params-column -->
 
                 <!-- Right Column for Placement -->


### PR DESCRIPTION
This commit introduces a new feature allowing you to design a heatsink and calculate its total contact area with the air.

The feature includes:
- UI elements in `templates/index.html` for specifying dimensions of the heatsink base, main fins, and hollow fins (channels on main fins).
- Client-side JavaScript in `static/js/script.js` to capture your inputs, perform basic validation, and send data to the backend.
- A new Python function `calculate_heatsink_contact_area` in `simulador_core.py` that implements the area calculation logic, including detailed validation of input dimensions and constraints. The calculation accounts for the heatsink base, fin surfaces (sides, top, and ends), and the net change in area due to hollow fin channels.
- A new Flask API endpoint `/calculate_heatsink_area` in `app.py` that receives data from the frontend, calls the calculation function, and returns the result or an error message as JSON.

The calculation logic handles cases with no fins, and validates constraints such as fins not exceeding heatsink dimensions and hollow fins not exceeding main fin dimensions.