### PR TITLE
Implementar entrada manual de Rth del disipador

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -254,3 +254,40 @@ body.loading { cursor: wait; }
     .creator-info-page h2 { font-size: 1.2em; margin-top: 20px; margin-bottom: 10px;}
     #bibliography ul { padding-left: 20px;}
 }
+
+/* Estilos para el grupo de Rth Manual */
+.rth-manual-group {
+    /* display: flex; Ya está en .input-group, que es el padre de .rth-manual-group */
+    /* align-items: center; Ya está en .input-group */
+    /* gap: 8px; Ya está en .input-group */
+}
+
+.rth-manual-group label[for="rth_heatsink_manual"] {
+    /* flex-basis: 160px; Heredado de .input-group label */
+    /* text-align: right; Heredado de .input-group label */
+}
+
+.rth-manual-group input[type="number"]#rth_heatsink_manual {
+    /* flex-grow: 1; Heredado de .input-group input[type="number"] */
+    /* min-width: 70px; Heredado */
+    /* max-width: 120px; Heredado */
+    /* No es necesario repetir estilos ya definidos en .input-group input[type="number"] */
+}
+
+.rth-manual-group input[type="checkbox"]#use_manual_rth_checkbox {
+    margin-left: 2px; /* Ajuste fino si el gap no es perfecto */
+    margin-right: 5px;
+    transform: scale(1.1);
+    cursor: pointer;
+    flex-shrink: 0; /* Importante para que no se encoja */
+}
+
+.rth-manual-group label.checkbox-label[for="use_manual_rth_checkbox"] {
+    flex-basis: auto; /* Permitir que el label tome el ancho necesario */
+    text-align: left;
+    font-size: 0.85em;
+    color: #555;
+    cursor: pointer;
+    font-weight: normal; /* Evitar negrita si .input-group label lo tuviera */
+    margin-right: 0; /* No necesita margen si es el último */
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,7 +37,13 @@
                         <div class="input-group"> <label for="ly">Width (Y) [m]:</label> <input type="number" id="ly" name="ly" value="{{ initial_heatsink.ly }}" step="0.01" min="0.01" required title="Heatsink width in the Y direction (airflow direction, depth of cross-section)"> </div>
                         <div class="input-group"> <label for="t">Base Thickness (t) [m]:</label> <input type="number" id="t" name="t" value="{{ initial_heatsink.t }}" step="0.001" min="0.001" required title="Thickness of the heatsink baseplate"> </div>
                         <div class="input-group"> <label for="k_base">Conductivity (k) [W/mK]:</label> <input type="number" id="k_base" name="k_base" value="{{ initial_heatsink.k_base }}" step="1" min="0.1" required title="Thermal conductivity of the heatsink base material (e.g., Al ≈ 218, Cu ≈ 390)"> </div>
-                        <div class="input-group"> <label for="rth_heatsink">Total Heatsink Rth [°C/W]:</label> <input type="number" id="rth_heatsink" name="rth_heatsink" value="{{ initial_heatsink.rth_heatsink }}" step="0.0001" min="0.0001" required title="Total equivalent thermal resistance. Used if detailed fin calcs fail or for 'no modules' case."> </div>
+                        <div class="input-group"> <label for="rth_heatsink">Fallback Heatsink Rth [°C/W]:</label> <input type="number" id="rth_heatsink" name="rth_heatsink" value="{{ initial_heatsink.rth_heatsink }}" step="0.0001" min="0.0001" required title="Fallback total equivalent thermal resistance. Used if detailed fin calcs fail or for 'no modules' case."> </div>
+                        <div class="input-group rth-manual-group">
+                            <label for="rth_heatsink_manual">Manual Rth [°C/W]:</label>
+                            <input type="number" id="rth_heatsink_manual" name="rth_heatsink_manual" value="0.015" step="0.0001" min="0.0001" title="Manually input heatsink thermal resistance. If checked, this value will be used directly.">
+                            <input type="checkbox" id="use_manual_rth_checkbox" name="use_manual_rth_checkbox" title="Check to use the manually entered Rth value. Uncheck to calculate Rth based on fin geometry and flow.">
+                            <label for="use_manual_rth_checkbox" class="checkbox-label">Use Manual Rth</label>
+                        </div>
                     </fieldset>
 
                     <fieldset class="params-fieldset" id="fin-design-params-fieldset">


### PR DESCRIPTION
Se añade la funcionalidad para que el usuario pueda introducir directamente la resistencia térmica (Rth) del disipador.

Características:
- Nuevo campo de entrada en la UI para Rth manual y un checkbox para activar/desactivar esta opción.
- Si se activa la Rth manual, el coeficiente de convección 'h' se calcula directamente como h = 1 / (Rth_manual * Area_heatsink) y se omite la iteración de 'h'.
- Si no se activa, 'h' se calcula iterativamente como antes.
- El backend y el core de simulación se han actualizado para manejar estos nuevos parámetros.
- El informe PDF ahora indica si se usó Rth manual y su valor, o si fue calculada.